### PR TITLE
feat: project rasters in the desired map projection

### DIFF
--- a/models/raster.py
+++ b/models/raster.py
@@ -3,8 +3,12 @@ import zarr
 from rasterio.coords import BoundingBox
 from rasterio.io import DatasetReader
 from rasterio.mask import mask
-from rasterio.transform import AffineTransformer
+from rasterio import Affine
 from shapely.geometry import Polygon
+from rasterio.warp import calculate_default_transform, reproject, \
+    Resampling, transform_bounds
+
+from utils.geometry import projectPolygon
 
 DTYPE_BYTES = {
     'byte': 1,
@@ -27,19 +31,24 @@ class Raster:
     width: int
     height: int
     bounds: BoundingBox
-    transform: AffineTransformer
+    transform: Affine
     dtype: str
     crs: str
 
     def __init__(self, band: str, rasterReader: DatasetReader,
-                 polygon: Polygon = None):
+                 targetProjection, polygon: Polygon = None):
         self.band = band
         self.dtype = rasterReader.dtypes[0].lower()
-        self.crs = rasterReader.crs.to_string()
+        self.crs = targetProjection
 
+        # If there is a polygon, extract the ROI in local referential
         if polygon:
-            self.rasterData, self.transform = mask(rasterReader,
-                                                   [polygon], crop=True)
+            localProjectionPolygon = projectPolygon(
+                polygon, targetProjection, rasterReader.crs)
+
+            self.rasterData, src_transform = mask(
+                rasterReader, [localProjectionPolygon], crop=True)
+
             self.rasterData = np.squeeze(self.rasterData)
 
             self.width = self.rasterData.shape[1]
@@ -54,17 +63,34 @@ class Raster:
                     (bounds.left, bounds.top),
                     (bounds.left, bounds.bottom)])
 
-            intersectionBounds = polygon.intersection(rasterPolygon).bounds
-            self.bounds = BoundingBox(intersectionBounds[0],
-                                      intersectionBounds[1],
-                                      intersectionBounds[2],
-                                      intersectionBounds[3])
+            intersectionBounds = localProjectionPolygon.intersection(
+                rasterPolygon).bounds
+            self.bounds = BoundingBox(*intersectionBounds)
         else:
             self.rasterData = rasterReader.read(1)
             self.width = rasterReader.width
             self.height = rasterReader.height
             self.bounds = rasterReader.bounds
-            self.transform = rasterReader.transform
+            src_transform = rasterReader.transform
+
+        # Project the raster in the target projection
+        self.transform, self.width, self.height = calculate_default_transform(
+            rasterReader.crs, targetProjection,
+            self.width, self.height, *self.bounds)
+
+        self.bounds = transform_bounds(
+            rasterReader.crs, targetProjection, *self.bounds)
+
+        projectedRasterData = np.zeros((self.height, self.width))
+
+        reproject(source=self.rasterData,
+                  destination=projectedRasterData,
+                  src_crs=rasterReader.crs,
+                  src_transform=src_transform,
+                  dst_crs=targetProjection,
+                  dst_transform=self.transform,
+                  resampling=Resampling.nearest)
+        self.rasterData = projectedRasterData
 
     def createZarrStore(self, zarrRootPath: str,
                         productTime: int, chunkMbs=1) -> zarr.DirectoryStore:

--- a/models/rasterDrivers/abstractRasterArchive.py
+++ b/models/rasterDrivers/abstractRasterArchive.py
@@ -16,8 +16,8 @@ class AbstractRasterArchive(abc.ABC):
 
     # Loosely inspired from
     # https://gist.github.com/lucaswells/fd2fd73c513872966c1a0257afee1887
-    def buildZarr(self, zarrPath, polygon: Polygon = None,
-                  chunkMbs=1) -> xr.Dataset:
+    def buildZarr(self, zarrPath, targetProjection: str,
+                  polygon: Polygon = None, chunkMbs=1) -> xr.Dataset:
         """
         Build a chunked and compressed zarr from raster files.
 
@@ -42,7 +42,7 @@ class AbstractRasterArchive(abc.ABC):
         for band, rasterPath in self.bandsToExtract.items():
             with rasterio.open(rasterPath) as rasterReader:
                 # Create Raster object
-                raster = Raster(band, rasterReader, polygon)
+                raster = Raster(band, rasterReader, targetProjection, polygon)
                 dtype = raster.dtype
 
                 # Create zarr store

--- a/rest_api/datacube.py
+++ b/rest_api/datacube.py
@@ -38,6 +38,10 @@ DATACUBE_BUILD_REQUEST = api.model(
         "targetResolution": fields.Integer(
             readonly=True,
             description="The requested end resolution in meters"
+        ),
+        "targetProjection": fields.String(
+            readonly=True,
+            description="The targeted projection. By default is 'EPSG:4326'."
         )
     }
 )
@@ -55,7 +59,8 @@ class DataCube_Build(Resource):
         'dataCubePath': 'The Object Store path to the data cube',
         'roi': 'The Region Of Interest (bbox) to extract',
         'bands': 'The list of bands to extract',
-        'targetResolution': 'The requested end resolution in meters'
+        'targetResolution': 'The requested end resolution in meters',
+        'tragetProjection': 'The targeted projection. By default is "EPSG:4326".'
         })
     @api.expect(DATACUBE_BUILD_REQUEST)
     def post(self):
@@ -69,6 +74,10 @@ class DataCube_Build(Resource):
         targetResolution = api.payload["targetResolution"] \
             if "targetResolution" in api.payload \
             else 10
+
+        targetProjection = api.payload["tragetProjection"] \
+            if "tragetProjection" in api.payload \
+            else "EPSG:4326"
 
         parsedDestination = urlparse(api.payload["dataCubePath"])
 
@@ -97,7 +106,7 @@ class DataCube_Build(Resource):
 
                 dataset = rasterArchive.buildZarr(
                   f"{parsedDestination.netloc}/{parsedDestination.path}_{idx}",
-                  polygon=polygon)
+                  targetProjection, polygon=polygon)
                 datasets.append(dataset)
             except Exception as e:
                 api.logger.error(e)

--- a/scripts/tests/build-datacube.sh
+++ b/scripts/tests/build-datacube.sh
@@ -8,6 +8,7 @@ curl -X POST -H "Content-Type: application/json" -d '{
         }
     ],
     "dataCubePath": "gs://gisaia-datacube/S2A_MSIL2A_20221017T105041_N0400_R051_T30TXN_20221017T170159_B01",
-    "roi": "640000.0,4720000.0,700000.0,4780000.0",
-    "bands": ["B01"]
+    "roi": "-1.17,42.37,-0.32,43.85",
+    "bands": ["B01"],
+    "targetResolution": 60
     }' http://localhost:5000/datacube/build

--- a/tests/reproject.py
+++ b/tests/reproject.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+
+import sys
+from pathlib import Path
+from time import time
+import rasterio
+from rasterio.warp import calculate_default_transform, reproject, Resampling, transform_bounds
+import numpy as np
+from rasterio.mask import mask
+from shapely.geometry import Polygon
+
+from rasterio.coords import BoundingBox
+
+ROOT_PATH = str(Path(__file__).parent.parent)
+sys.path.insert(0, ROOT_PATH)
+
+from utils.geometry import projectPolygon
+
+
+IN_PATH = "../data/S2A_MSIL2A_20220809T102041_N0400_R065_T32TML_20220809T180703.SAFE/GRANULE/L2A_T32TML_A037242_20220809T102107/IMG_DATA/R10m/T32TML_20220809T102041_B02_10m.jp2"
+OUT_PATH = "../data/reproj/test.jp2"
+
+ROI = [8, 40.8, 9, 42]
+DIST_CRS = {"init": 'EPSG:4326'}
+
+with rasterio.open(IN_PATH) as src:
+    print(src.crs)
+
+    roi_local = transform_bounds(DIST_CRS, src.crs, *ROI)
+    bounds = src.bounds
+    rasterPolygon = Polygon([
+            (bounds.left, bounds.bottom),
+            (bounds.right, bounds.bottom),
+            (bounds.right, bounds.top),
+            (bounds.left, bounds.top),
+            (bounds.left, bounds.bottom)])
+
+    polygon = Polygon([
+            (roi_local[0], roi_local[1]),
+            (roi_local[2], roi_local[1]),
+            (roi_local[2], roi_local[3]),
+            (roi_local[0], roi_local[3]),
+            (roi_local[0], roi_local[1])])
+
+    projectPolygon(polygon, src.crs, 'EPSG:4326')
+    intersectionBounds = polygon.intersection(rasterPolygon).bounds
+    bounds = BoundingBox(intersectionBounds[0],
+                         intersectionBounds[1],
+                         intersectionBounds[2],
+                         intersectionBounds[3])
+
+    start_time = time()
+
+    rasterData: np.ndarray
+    rasterData, _ = mask(src, [polygon], crop=True)
+
+    dst_transform, width, height = calculate_default_transform(
+        src.crs, DIST_CRS, rasterData.shape[0], rasterData.shape[1], *bounds)
+
+    print(src.transform)
+    print()
+    print(dst_transform)
+    print(src.width, width)
+    print(src.height, height)
+
+    dst = np.zeros((width, height))
+
+    kwargs = src.meta.copy()
+
+    kwargs.update({
+            'crs': DIST_CRS,
+            'transform': dst_transform,
+            'width': width,
+            'height': height})
+
+    with rasterio.open(OUT_PATH, 'w', **kwargs) as destination:
+        reproject(
+            source=rasterio.band(src, 1),
+            destination=rasterio.band(destination, 1),
+            src_transform=src.transform,
+            src_crs=src.crs,
+            dst_transform=dst_transform,
+            dst_crs=DIST_CRS,
+            resampling=Resampling.nearest
+        )
+
+    print(time() - start_time)
+    print(dst)

--- a/utils/geometry.py
+++ b/utils/geometry.py
@@ -1,6 +1,7 @@
 import string
 
 from shapely.geometry import Point, Polygon
+from rasterio.warp import transform_geom
 
 
 def bbox2polygon(bbox: string):
@@ -15,3 +16,17 @@ def bbox2polygon(bbox: string):
     righttop = Point(float(corners[2]), float(corners[3]))
 
     return Polygon([leftbot, rightbot, righttop, lefttop, leftbot])
+
+
+def projectPolygon(polygon: Polygon, src_crs: str, dst_crs: str) -> Polygon:
+    """
+    Project a polygon in the desired projection
+    """
+    x, y = polygon.exterior.coords.xy
+
+    return Polygon(transform_geom(
+        src_crs, dst_crs,
+        {
+            'type': polygon.geom_type,
+            'coordinates': [list(zip(x, y))]
+        })["coordinates"][0])


### PR DESCRIPTION
With an input ROI polygon in the desired projection, projects it in the local projection of the granules, to then extract the ROI.
Projects the extracted raster into the target projection, and then continues the processing as before.